### PR TITLE
feat(pipeline): 添加颜色辅助OCR识别方法

### DIFF
--- a/Storage/pipelines/overflow65537/color-match-ocr-only-rec/README.md
+++ b/Storage/pipelines/overflow65537/color-match-ocr-only-rec/README.md
@@ -1,0 +1,148 @@
+# ColorMatch + OCR only_rec 精准识文
+
+## 适用场景
+
+某些界面 OCR 直接扫整块 ROI 时，容易出现：
+
+- 识别准确率低
+- 把背景文字、相邻数字一起读入
+- 固定显示 `0` 与有效数值难以区分
+
+本范式先用 **ColorMatch** 按文字颜色圈出目标区域，再对该区域开 **OCR + only_rec** 做纯识别，缩小干扰范围。
+
+## 核心思路
+
+```
+ColorMatch 找到文字颜色区域（sub_name 锚点）
+        ↓
+OCR.roi 引用锚点，only_rec: true 只识别不检测
+        ↓
+expected 正则区分「有数值」与「无数值（0）」
+```
+
+`And` 组合两步：颜色匹配命中 **且** OCR 结果符合预期，节点才算识别成功。
+
+## 节点示例
+
+### 检查是否存在数值
+
+ColorMatch 定位白色文字区域，OCR 匹配**非 0** 的任意内容：
+
+```json
+"检查是否存在数值": {
+    "recognition": {
+        "type": "And",
+        "param": {
+            "all_of": [
+                {
+                    "sub_name": "_文字颜色",
+                    "recognition": {
+                        "type": "ColorMatch",
+                        "param": {
+                            "roi": [884, 162, 260, 55],
+                            "lower": [240, 240, 240],
+                            "upper": [255, 255, 255],
+                            "count": 10
+                        }
+                    }
+                },
+                {
+                    "recognition": {
+                        "type": "OCR",
+                        "param": {
+                            "roi": "_文字颜色",
+                            "expected": "^(?!^0$).+$",
+                            "only_rec": true
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+| 字段                      | 作用                                           |
+| ------------------------- | ---------------------------------------------- |
+| `sub_name`                | 给 ColorMatch 子结果命名，供 OCR 的 `roi` 引用 |
+| `lower` / `upper`         | 文字颜色的 RGB 范围                            |
+| `count`                   | 符合颜色的最少像素数，过滤噪点                 |
+| `roi: "_文字颜色"`        | OCR 只在颜色匹配到的区域内识别                 |
+| `only_rec: true`          | 跳过文字检测，直接识别（需 ROI 已精确）        |
+| `expected: "^(?!^0$).+$"` | 匹配任意非 `0` 字符串                          |
+
+### 没有数值
+
+结构相同，OCR 改为只认 **`0`**：
+
+```json
+"没有数值": {
+    "recognition": {
+        "type": "And",
+        "param": {
+            "all_of": [
+                {
+                    "sub_name": "_文字颜色",
+                    "recognition": {
+                        "type": "ColorMatch",
+                        "param": {
+                            "roi": [884, 162, 260, 55],
+                            "lower": [240, 240, 240],
+                            "upper": [255, 255, 255],
+                            "count": 10
+                        }
+                    }
+                },
+                {
+                    "recognition": {
+                        "type": "OCR",
+                        "param": {
+                            "roi": "_文字颜色",
+                            "expected": "^0$",
+                            "only_rec": true
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+## 组合使用
+
+两个节点通常配合 `Or` / `And` 做流程分支：
+
+```json
+"最终状态但没有数值": {
+    "recognition": {
+        "type": "And",
+        "param": {
+            "all_of": [
+                "检查是否是最终状态",
+                "没有数值"
+            ]
+        }
+    }
+},
+"需要进行任务": {
+    "recognition": {
+        "type": "Or",
+        "param": {
+            "any_of": [
+                "不是最终状态",
+                "最终状态但没有数值"
+            ]
+        }
+    }
+}
+```
+
+完整可引用示例见同目录 `pipeline.json`。
+
+## 调参建议
+
+- **颜色范围**：用截图工具取目标文字 RGB，适当放宽 `lower` / `upper`，或者使用HSV或者灰度
+- **`count`**：文字较小时适当降低，背景噪点多时适当提高
+- **`roi`**：ColorMatch 的 ROI 应覆盖文字可能出现范围，不必与 OCR 最终区域完全相同，如果发生文字边缘颜色不一致，可以使用`roi_offset`对识别区进行微调
+- **`only_rec`**：依赖 ROI 足够准；若 ColorMatch 锚点偏移，OCR 结果会不稳定

--- a/Storage/pipelines/overflow65537/color-match-ocr-only-rec/maahub_meta.json
+++ b/Storage/pipelines/overflow65537/color-match-ocr-only-rec/maahub_meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "overflow65537/color-match-ocr-only-rec",
+  "title": "ColorMatch + OCR only_rec 精准识文",
+  "description": "先用颜色匹配定位文字颜色区域，再对该区域开启 only_rec 做 OCR，提升低准确率或易混淆场景下的识别稳定性。",
+  "author": "overflow65537",
+  "source": "MAA_Punish",
+  "sourceGithub": "https://github.com/MaaXYZ/MaaHub",
+  "tags": ["pipeline", "ColorMatch", "OCR", "only_rec", "And"],
+  "createdAt": "2026-06-28",
+  "updatedAt": "2026-06-28",
+  "version": "0.1.0",
+  "mfwVersion": "5.10.4",
+  "entry": "pipeline.json",
+  "readme": "./README.md",
+  "status": "stable",
+  "type": "pipeline",
+  "category": "recognition",
+  "externalTools": []
+}

--- a/Storage/pipelines/overflow65537/color-match-ocr-only-rec/pipeline.json
+++ b/Storage/pipelines/overflow65537/color-match-ocr-only-rec/pipeline.json
@@ -1,0 +1,90 @@
+{
+    "检查是否存在数值": {
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    {
+                        "sub_name": "_文字颜色",
+                        "recognition": {
+                            "type": "ColorMatch",
+                            "param": {
+                                "roi": [884, 162, 260, 55],
+                                "lower": [240, 240, 240],
+                                "upper": [255, 255, 255],
+                                "count": 10
+                            }
+                        }
+                    },
+                    {
+                        "recognition": {
+                            "type": "OCR",
+                            "param": {
+                                "roi": "_文字颜色",
+                                "expected": "^(?!^0$).+$",
+                                "only_rec": true
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "没有数值": {
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    {
+                        "sub_name": "_文字颜色",
+                        "recognition": {
+                            "type": "ColorMatch",
+                            "param": {
+                                "roi": [884, 162, 260, 55],
+                                "lower": [240, 240, 240],
+                                "upper": [255, 255, 255],
+                                "count": 10
+                            }
+                        }
+                    },
+                    {
+                        "recognition": {
+                            "type": "OCR",
+                            "param": {
+                                "roi": "_文字颜色",
+                                "expected": "^0$",
+                                "only_rec": true
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "最终状态但没有数值": {
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "检查是否是最终状态",
+                    "没有数值"
+                ]
+            }
+        }
+    },
+    "需要进行任务": {
+        "recognition": {
+            "type": "Or",
+            "param": {
+                "any_of": [
+                    "不是最终状态",
+                    "最终状态但没有数值"
+                ]
+            }
+        },
+        "next": ["任务入口"]
+    },
+    "检查是否是最终状态": {},
+    "不是最终状态": {},
+    "任务入口": {}
+}


### PR DESCRIPTION
…README and configuration

## Summary by Sourcery

引入一个新的流水线变体，将 ColorMatch 与 OCR-only_rec 结合使用，以提升数字文本识别的准确性，并区分有意义的数值与固定的零显示。

新功能：
- 为 overflow65537 场景添加一个 color-match-ocr-only-rec 流水线配置，通过文本颜色来锚定 OCR ROI，并使用正则表达式对结果进行校验。

文档：
- 添加一份 README，描述 ColorMatch + OCR only_rec 流水线、使用模式、示例节点配置以及调优指南。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new pipeline variant that combines ColorMatch with OCR-only_rec to improve numeric text recognition accuracy and distinguish meaningful values from fixed zero displays.

New Features:
- Add a color-match-ocr-only-rec pipeline configuration for overflow65537 scenes that anchors OCR ROI by text color and validates results via regex.

Documentation:
- Add a README describing the ColorMatch + OCR only_rec pipeline, usage patterns, example node configurations, and tuning guidelines.

</details>