### PR TITLE
feat(customs): add maafw custom

### DIFF
--- a/Storage/customs/huzesama/swipe-in-box-by-vector/README.md
+++ b/Storage/customs/huzesama/swipe-in-box-by-vector/README.md
@@ -1,0 +1,27 @@
+# ONNX Detect IoU
+
+## 功能
+
+- 根据识别到的Box向指定方向滑动
+
+## 文件说明
+
+- `swipe_inBoxByVector.py`：Action 实现
+- `pipeline.json`：pipeline 示例
+
+## 使用方式
+
+`custom_action_param` 参数：
+
+- `node_name`：节点命中且有识别结果box的节点名（可选）；默认使用当前动作节点自身的识别结果
+- `vector`: 滑动向量（必填）：`[int,"xx%"]`支持含%的字符串，例如`[0,"10%"]`则为向下滑动10% Box 边长的像素长度
+- `duration`: 滑动耗时（可选）。默认：`200`ms
+- `random_begin`: 随机起点。布尔值。不随机时选取box中点为起点。默认：`False`
+
+示例可见 `pipeline.json`。
+
+## 依赖
+
+- Python
+- MaaFramework Agent SDK（`maa.custom_action`）
+- onnx runtime

--- a/Storage/customs/huzesama/swipe-in-box-by-vector/maahub_meta.json
+++ b/Storage/customs/huzesama/swipe-in-box-by-vector/maahub_meta.json
@@ -1,0 +1,20 @@
+{
+  "id": "huzesama/swipe-in-box-by-vector",
+  "title": "Swipe in box by vector",
+  "description": "根据识别到的Box向指定方向滑动。解决内置动作swipe在begin和end选择同一node_name并配合target_offset字段时，选点不同导致会朝不同方向滑动的问题。使用场景为不确定位置的大目标列表且没有参照滑动终点的特殊场景。",
+  "author": "huzesama",
+  "source": "MaaWoA",
+  "sourceGithub": "https://github.com/huzesama/MaaHub",
+  "tags": ["custom", "action", "swipe", "python"],
+  "createdAt": "2026-08-20",
+  "updatedAt": "2026-08-20",
+  "version": "0.0.1",
+  "mfwVersion": "5.12.2",
+  "entry": "swipe_inBoxByVector.py",
+  "readme": "./README.md",
+  "status": "stable",
+  "type": "custom",
+  "language": "python",
+  "runtime": "python 3.14.6",
+  "dependencies": ["maa framework sdk"]
+}

--- a/Storage/customs/huzesama/swipe-in-box-by-vector/pipeline.json
+++ b/Storage/customs/huzesama/swipe-in-box-by-vector/pipeline.json
@@ -1,0 +1,20 @@
+{
+	"自定义Box内滑动": {
+		"recognition": "directHit",
+		"action": {
+			"type": "Custom",
+			"param": {
+				"custom_action": "swipe_inBoxByVector",
+				"custom_action_param": {
+					"node_name": "RecignitionNode",
+					"vector": [
+						0,
+						"50%"
+					],
+					"duration": 300,
+					"random_begin": true
+				}
+			}
+		}
+	}
+}

--- a/Storage/customs/huzesama/swipe-in-box-by-vector/swipe_inBoxByVector.py
+++ b/Storage/customs/huzesama/swipe-in-box-by-vector/swipe_inBoxByVector.py
@@ -1,0 +1,101 @@
+import sys
+import json
+import random
+
+from maa.agent.agent_server import AgentServer
+from maa.custom_action import CustomAction
+from maa.context import Context
+from maa.tasker import Tasker
+
+
+def resolve_vector_component(value, length: int) -> int:
+	#解析向量的单个分量：支持固定像素值(int)或百分比字符串("60%")
+	#百分比模式下，实际偏移量 = 百分比 * box 对应边长
+
+	if isinstance(value, str) and value.strip().endswith("%"):
+		percent = float(value.strip().rstrip("%")) / 100.0
+		return int(length * percent)
+	return int(value)
+
+
+@AgentServer.custom_action("swipe_inBoxByVector")
+class swipe_inBoxByVector(CustomAction):
+	#自定义动作：根据指定节点命中的 box 坐标为起点（或 box 内随机一点），
+	#按传入的向量 (dx, dy) 进行滑动。向量支持固定像素或百分比（相对 box 宽高）。
+
+	def run(
+		self,
+		context: Context,
+		argv: CustomAction.RunArg,
+	) -> bool:
+		# 解析 pipeline 里传入的 custom_action_param（JSON 字符串）
+		param = json.loads(argv.custom_action_param or "{}")
+
+		# 要取哪个节点命中的 box；不传则使用当前动作节点自身的识别结果
+		target_node = param.get("node_name")
+		# 滑动向量 [dx, dy]，可以是 int（像素）或 "xx%"（box 边长的百分比）
+		vector = param.get("vector", [0, 0])
+		# 滑动耗时（毫秒）
+		duration = param.get("duration", 200)
+		# 起点是否在 box 内随机取一点，默认 False（取 box 中心）
+		random_begin = param.get("random_begin", False)
+
+		if target_node:
+			node_detail = context.tasker.get_latest_node(target_node)
+			if not node_detail or not node_detail.recognition or not node_detail.recognition.best_result:
+				print(f"[SwipeByVector] node '{target_node}' has no recognition result")
+				return False
+			box = node_detail.recognition.box
+		else:
+			box = argv.box
+		print(f"box:'{box}'")
+		if not box:
+			# 没有可用的 box，直接返回失败
+			print(f"[SwipeByVector] node '{target_node}' has no box")
+			return False
+		
+		# 解包 box：左上角坐标 (x, y) 和宽高 (w, h)
+		x, y, w, h = box
+
+		if random_begin:
+			# 在 box 内随机取一点作为起点
+			start_x = x + random.randint(0, max(w - 1, 0))
+			start_y = y + random.randint(0, max(h - 1, 0))
+		else:
+			# 以 box 中心作为滑动起点
+			start_x, start_y = x + w // 2, y + h // 2
+
+		# 解析向量的 dx, dy：支持固定像素或百分比（相对 box 宽/高）
+		dx = resolve_vector_component(vector[0], w)
+		dy = resolve_vector_component(vector[1], h)
+
+		# 终点 = 起点 + 解析后的向量偏移
+		end_x, end_y = start_x + dx, start_y + dy
+
+		# 通过 controller 发起滑动操作，并等待执行完成
+		controller = context.tasker.controller
+		controller.post_swipe(start_x, start_y, end_x, end_y, duration).wait()
+
+		return True
+
+
+def main():
+	# Agent 子进程入口：由框架传入 socket_id 作为唯一参数
+	if len(sys.argv) < 2:
+		print("Usage: python swipe_inBoxByVector.py <socket_id>")
+		exit(1)
+
+	socket_id = sys.argv[-1]
+
+	# 设置日志输出目录，便于调试
+	Tasker.set_log_dir("./debug")
+
+	# 启动 Agent 服务，注册的自定义动作/识别会在此进程内生效
+	AgentServer.start_up(socket_id)
+	# 阻塞等待，直到主进程通知关闭
+	AgentServer.join()
+	AgentServer.shut_down()
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
根据识别到的Box向指定方向滑动。解决内置动作swipe在begin和end选择同一node_name并配合target_offset字段时，选点不同导致会朝不同方向滑动的问题。使用场景为不确定位置的大目标列表且没有参照滑动终点的特殊场景。

## Summary by Sourcery

在目标端点不可用时，为方向手势添加一个基于边界框向量滑动的自定义动作。

新特性：
- 添加一个自定义动作，从检测到的边界框沿指定方向执行滑动。
- 支持固定像素或相对于边界框百分比的滑动向量、可选的随机起始点、可配置的持续时间，以及从其他节点选择识别结果。

文档：
- 记录该自定义动作的参数、用法、依赖项，并提供一个流水线示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a bounding-box vector swipe custom action for directional gestures when a target endpoint is unavailable.

New Features:
- Add a custom action that swipes from a detected bounding box in a specified direction.
- Support fixed-pixel or box-relative percentage swipe vectors, optional random starting points, configurable duration, and selecting recognition results from another node.

Documentation:
- Document the custom action parameters, usage, dependencies, and provide a pipeline example.

</details>